### PR TITLE
Add slinky pv configuration files

### DIFF
--- a/storage/redis-pv.yaml
+++ b/storage/redis-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: redis-pv
+  labels:
+    type: local
+spec:
+  storageClassName: "manual"
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: "/data"

--- a/storage/storage.md
+++ b/storage/storage.md
@@ -2,7 +2,7 @@
 
 Up to: [DataONE Cluster Overview](../cluster-overview.md)
 
-The DataONE Kuberrnetes netwrok needs access to both local and persistent storage for use by both the cluster services and by applications that we deploy on the service. 
+The DataONE Kubernetes network needs access to both local and persistent storage for use by both the cluster services and by applications that we deploy on the service.
 
 ## Host-based local storage
 

--- a/storage/virtuoso-pv.yaml
+++ b/storage/virtuoso-pv.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: virtuoso-pv
+  labels:
+    type: local
+spec:
+  storageClassName: "manual"
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: "/data"

--- a/storage/worker-pv.yaml
+++ b/storage/worker-pv.yaml
@@ -1,0 +1,15 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: worker-pv
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/worker"
+


### PR DESCRIPTION
This is a PR to open the discussion of handling persistent volume configurations. It includes three K8 configuration files-one for each volume in the _slinky_ deployment.

### File Organization
I've listed a few alternative ways to organize the files in this directory. The most straightforward way to install each volume is `kubectl apply -f <filename>`.

#### Single Project Configuration File
In this approach, each project has a single yaml file that contains all of the persistent volume definitions. For example, instead of the three files in this PR, there would be a single `slinky-pv.yaml` that contains the three pv declerations.

#### Unique PV Configuration File
In this approach, each persistent volume has its own file. This is the method that I picked for this PR. One extension is to create a directory for each deployment (ie `bookkeeper/`, `slinky/`) and apply this convention there (sounds over complex to me). I liked this method because it allows you to run kubectl `apply`, `patch`, `update` on individual definitions which is either not possible or more involved when bundling many definitions in a single file.

#### Single Configuration File
An alternative is to have a single file, `volumes.yaml` that has all of the volume declarations inside.

### Relation to Automated Deployments
Keeping the PV declarations as Kubernetes config files should integrate with a method for automating the instillation of these. I think that at the end of the day it will either be something like a shell script running `kubectl apply` for each file, _or_ something much larger like a helm chart. Both cases should easily support what's been done in this PR.
