### PR TITLE
Allow read-only access ('kubectl get') on rbac roles and rolebindings

### DIFF
--- a/authorization/application-context.yaml
+++ b/authorization/application-context.yaml
@@ -25,6 +25,10 @@ rules:
   - jobs
   - cronjobs
   verbs: ["*"]
+  ## Allow read-only access ('kubectl get') on rbac roles and rolebindings:
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get"]
 
 ---
 kind: RoleBinding


### PR DESCRIPTION
see #48 