### PR TITLE
add resources to yaml

### DIFF
--- a/postgres/postgres.md
+++ b/postgres/postgres.md
@@ -137,7 +137,18 @@ spec:
   storage:
     storageClass: csi-cephfs-sc
     size: 5Gi
+  resources:  # see note below
+    requests:
+      requests:
+        cpu: 1
+        memory: 1Gi
+      limits:
+        cpu: 1
+        memory: 1Gi
+    parameters:
+      shared_buffers: 256MB
 ```
+> [!NOTE] always set resoiurce requests and limits. The [CNPG docs recommend](https://cloudnative-pg.io/documentation/1.20/resource_management/) setting limits and requests for both memory and CPU to the same value, so your cluster's pods get assigned to the "Guaranteed" QoS class
 
 Now the database is named `keycloak` and other DB options have been set:
 


### PR DESCRIPTION
Currently the CNPG operator does not add default `resources` when creating pods, so we should add these to our yaml